### PR TITLE
Add TaskBoard navigation

### DIFF
--- a/task-management.Web/Components/Layout/NavMenu.razor
+++ b/task-management.Web/Components/Layout/NavMenu.razor
@@ -14,10 +14,60 @@
                            IconColor="Color.Accent">Weather</FluentNavLink>
             <FluentNavLink Href="taskboards" Icon="@(new Icons.Regular.Size20.Folder())"
                            IconColor="Color.Accent">TaskBoards</FluentNavLink>
+            <FluentDivider />
+            @if (taskBoards != null)
+            {
+                @foreach (var taskBoard in taskBoards)
+                {
+                    <FluentNavLink Href="@($"taskboards/{taskBoard.Id}")" Icon="@(new Icons.Regular.Size20.Folder())"
+                                   IconColor="Color.Accent">@taskBoard.Name</FluentNavLink>
+                }
+            }
+            <FluentButton Appearance="Appearance.Accent" OnClick="OpenAddTaskBoardDialog">
+                <FluentIcon Value="@(new Icons.Regular.Size20.Add())" />
+                Add TaskBoard
+            </FluentButton>
         </FluentNavMenu>
     </nav>
 </div>
 
 @code {
     private bool expanded = true;
+    private List<TaskBoardDto>? taskBoards;
+
+    [Inject]
+    private ITaskBoardService TaskBoardService { get; set; } = default!;
+
+    [Inject]
+    private IDialogService DialogService { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        taskBoards = (await TaskBoardService.GetAllTaskBoardsAsync()).ToList();
+    }
+
+    private async Task OpenAddTaskBoardDialog()
+    {
+        var dialog = await DialogService.ShowDialogAsync<TaskBoardEditDialog>(
+            new TaskBoardEditModel(),
+            new DialogParameters()
+            {
+                Width = "480px",
+                Height = "240px",
+                Title = "Add New TaskBoard",
+                PreventDismissOnOverlayClick = true,
+                PreventScroll = true,
+            });
+
+        var result = await dialog.Result;
+        if (!result.Cancelled && result.Data != null)
+        {
+            var newTaskBoard = result.Data as TaskBoardDto;
+            if (newTaskBoard != null)
+            {
+                await TaskBoardService.CreateTaskBoardAsync(newTaskBoard);
+                taskBoards = (await TaskBoardService.GetAllTaskBoardsAsync()).ToList();
+            }
+        }
+    }
 }

--- a/task-management.Web/Components/Pages/TaskBoards.razor
+++ b/task-management.Web/Components/Pages/TaskBoards.razor
@@ -43,7 +43,7 @@ else
     </FluentDataGrid>
 
     <FluentStack Orientation="Orientation.Horizontal" HorizontalAlignment="HorizontalAlignment.Center">
-        <FluentButton Icon="@(new Icons.Filled.Size24.Add())" Text="Add TaskBoard" />
+        <FluentButton Icon="@(new Icons.Filled.Size24.Add())" Text="Add TaskBoard" OnClick="OpenAddTaskBoardDialog" />
     </FluentStack>
 }
 
@@ -101,5 +101,30 @@ else
     {
         await TaskBoardService.DeleteTaskBoardAsync(taskBoard.Id);
         taskBoards = await GetFromApi();
+    }
+
+    private async Task OpenAddTaskBoardDialog()
+    {
+        var dialog = await DialogService.ShowDialogAsync<TaskBoardEditDialog>(
+            new TaskBoardEditModel(),
+            new DialogParameters()
+            {
+                Width = "480px",
+                Height = "240px",
+                Title = "Add New TaskBoard",
+                PreventDismissOnOverlayClick = true,
+                PreventScroll = true,
+            });
+
+        var result = await dialog.Result;
+        if (!result.Cancelled && result.Data != null)
+        {
+            var newTaskBoard = result.Data as TaskBoardDto;
+            if (newTaskBoard != null)
+            {
+                await TaskBoardService.CreateTaskBoardAsync(newTaskBoard);
+                taskBoards = await GetFromApi();
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #5

Add a spacer, dynamic TaskBoard names, and a button to add a new task board in the navigation menu.

* Modify `task-management.Web/Components/Layout/NavMenu.razor` to include a spacer or line after the static links and before the dynamic links using FluentUI components for Blazor.
* Fetch TaskBoard names from the API and display them as dynamic links in the navigation menu.
* Add a `FluentButton` component to open a dialog for adding a new task board.
* Handle click event on task board names to show tasks related to that task board.
* Modify `task-management.Web/Components/Pages/TaskBoards.razor` to add a button to open the `TaskBoardEditDialog` for creating a new task board.
* Add a method to handle the creation of a new task board in `task-management.Web/Components/Pages/TaskBoards.razor`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bertusviljoen/blazor_task_management/pull/6?shareId=65ebc8f1-2978-4f4a-957e-5e6cd4593209).